### PR TITLE
Bugfix: Calling getkey(blocking=False) results in missed keyboard inputs

### DIFF
--- a/getkey/platforms.py
+++ b/getkey/platforms.py
@@ -113,7 +113,7 @@ class PlatformUnix(Platform):
     def context(self):
         fd = self.fileno()
         old_settings = self.termios.tcgetattr(fd)
-        self.tty.setcbreak(fd)
+        self.tty.setcbreak(fd, self.termios.TCSANOW)
         try:
             yield
         finally:


### PR DESCRIPTION
Inputs are missed, because when setting `tty.setcbreak` the default value
of the `when` argument is used which means that the option will have effect
after transmitting all queued output and discarding all queued input which
may not happen immediately so some inputs will be lost.

References:
	- https://docs.python.org/3/library/tty.html
 	- https://docs.python.org/3/library/termios.html#termios.tcsetattr